### PR TITLE
5 - Replace JSR-305 with Spotbugs annotations

### DIFF
--- a/src/main/java/hudson/plugins/parameterizedtrigger/BlockingBehaviour.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/BlockingBehaviour.java
@@ -32,7 +32,7 @@ import hudson.model.Descriptor;
 import hudson.model.Result;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import java.util.Arrays;
 import java.util.List;
 

--- a/src/main/java/hudson/plugins/parameterizedtrigger/BuildTriggerConfig.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/BuildTriggerConfig.java
@@ -42,7 +42,7 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -56,7 +56,7 @@ import java.util.StringTokenizer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.acegisecurity.AccessDeniedException;
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import jenkins.security.QueueItemAuthenticator;
 
 public class BuildTriggerConfig implements Describable<BuildTriggerConfig> {
@@ -267,7 +267,7 @@ public class BuildTriggerConfig implements Describable<BuildTriggerConfig> {
      * @return List of readable items, others will be skipped if {@link AccessDeniedException} happens
      */
     private static <T extends Item> List<T> readableItemsFromNameList(
-            ItemGroup context, @Nonnull String list, @Nonnull Class<T> type) {
+            ItemGroup context, @NonNull String list, @NonNull Class<T> type) {
         Jenkins hudson = Jenkins.get();
 
         List<T> r = new ArrayList<>();
@@ -418,7 +418,7 @@ public class BuildTriggerConfig implements Describable<BuildTriggerConfig> {
         return Collections.emptyList();
     }
 
-    private void reportSchedulingError(@Nonnull Run<?, ?> run, @Nonnull Job<?, ?> jobToTrigger, @Nonnull BuildListener listener) {
+    private void reportSchedulingError(@NonNull Run<?, ?> run, @NonNull Job<?, ?> jobToTrigger, @NonNull BuildListener listener) {
         // Do not print details to Build Listener, they have been reported previously in #canTriggerProject()
         listener.error("Skipping " + jobToTrigger.getFullName() + "...");
         if (LOGGER.isLoggable(Level.CONFIG)) {
@@ -543,8 +543,8 @@ public class BuildTriggerConfig implements Describable<BuildTriggerConfig> {
     }
     
     @CheckForNull
-    protected QueueTaskFuture schedule(@Nonnull AbstractBuild<?, ?> build, @Nonnull final Job project, int quietPeriod,
-            @Nonnull List<Action> list, @Nonnull TaskListener listener) throws InterruptedException, IOException {
+    protected QueueTaskFuture schedule(@NonNull AbstractBuild<?, ?> build, @NonNull final Job project, int quietPeriod,
+            @NonNull List<Action> list, @NonNull TaskListener listener) throws InterruptedException, IOException {
         // TODO Once it's in core (since 1.621) and LTS is out, switch to use new ParameterizedJobMixIn convenience method
         // From https://github.com/jenkinsci/jenkins/pull/1771
         Cause cause = createUpstreamCause(build);
@@ -582,8 +582,8 @@ public class BuildTriggerConfig implements Describable<BuildTriggerConfig> {
      * @return {@code true} if the project can be scheduled.
      *         {@code false} if there is a lack of permissions, details will be printed to the logs then.
      */
-    /*package*/ static boolean canTriggerProject(@Nonnull AbstractBuild<?, ?> build, 
-            @Nonnull final Job job, @Nonnull TaskListener taskListener) {
+    /*package*/ static boolean canTriggerProject(@NonNull AbstractBuild<?, ?> build,
+            @NonNull final Job job, @NonNull TaskListener taskListener) {
         if (!job.hasPermission(Item.BUILD)) {
             String message = String.format("Cannot schedule the build of %s from %s. "
                         + "The authenticated build user %s has no Job.BUILD permission",
@@ -601,7 +601,7 @@ public class BuildTriggerConfig implements Describable<BuildTriggerConfig> {
      * @param job Job to be checked
      * @return true if the job can be scheduled from the 
      */
-    protected boolean canBeScheduled(@Nonnull Job<?, ?> job) {
+    protected boolean canBeScheduled(@NonNull Job<?, ?> job) {
         if (!job.isBuildable()) {
             return false;
         }
@@ -618,7 +618,7 @@ public class BuildTriggerConfig implements Describable<BuildTriggerConfig> {
     }
     
     @CheckForNull
-    protected QueueTaskFuture schedule(@Nonnull AbstractBuild<?, ?> build, @Nonnull Job project, @Nonnull List<Action> list, @Nonnull TaskListener listener) throws InterruptedException, IOException {
+    protected QueueTaskFuture schedule(@NonNull AbstractBuild<?, ?> build, @NonNull Job project, @NonNull List<Action> list, @NonNull TaskListener listener) throws InterruptedException, IOException {
         if (project instanceof ParameterizedJobMixIn.ParameterizedJob) {
             return schedule(build, project, ((ParameterizedJobMixIn.ParameterizedJob) project).getQuietPeriod(), list, listener);
         } else {

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/ParameterizedTriggerPermissionTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/ParameterizedTriggerPermissionTest.java
@@ -50,8 +50,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import jenkins.model.Jenkins;
 import jenkins.security.QueueItemAuthenticator;
 import jenkins.security.QueueItemAuthenticatorConfiguration;
@@ -139,9 +139,9 @@ public class ParameterizedTriggerPermissionTest {
         Cause.UpstreamCause cause = lastBuild.getCause(Cause.UpstreamCause.class);
         assertNotNull("No upstream cause in subproject2", lastBuild);
     }
-    
-    @Nonnull
-    private FreeStyleProject createProjectWithPermissions(@Nonnull String projectName, @Nonnull String userName, 
+
+    @NonNull
+    private FreeStyleProject createProjectWithPermissions(@NonNull String projectName, @NonNull String userName,
             @CheckForNull List<Permission> permissions) throws Exception {
         final TreeSet<String> userSet = new TreeSet<>(Arrays.asList(userName));
         


### PR DESCRIPTION
## Replace JSR-305 annotations with Spotbugs annotations

JSR-305 was never adopted.  The Jenkins project has switched to Spotbugs annotations and provides them in the parent pom.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~
